### PR TITLE
모바일 반응형 처리 및 PC웹 InfoSection, Schedule 컴포넌트 비율 수정

### DIFF
--- a/client/src/Layout.module.css
+++ b/client/src/Layout.module.css
@@ -18,21 +18,21 @@
   flex-direction: row;
   gap: 20px;
   width: 100%;
-  max-width: 1200px; /* 최대 너비 제한 */
+  max-width: 1200px;
   margin: 0 auto;
-  overflow-x: auto; /* 가로 스크롤이 필요한 경우 스크롤바 표시 */
+  overflow-x: auto;
 }
 
 .infoSection {
-  flex: 0 0 65%;
-  min-width: 450px;
-  max-width: 800px; /* 최대 너비 제한 */
+  flex: 0 0 30%;
+  min-width: 280px;
+  max-width: 350px;
 }
 
 .schedule {
-  flex: 0 0 35%;
-  min-width: 280px;
-  max-width: 400px; /* 최대 너비 제한 */
+  flex: 0 0 70%;
+  min-width: 400px;
+  max-width: none;
 }
 
 /* 웹 화면에서의 레이아웃 */
@@ -43,12 +43,13 @@
   }
 
   .contentContainer {
+    flex-direction: column;
     gap: 15px;
   }
 
   .infoSection, .schedule {
-    min-width: 300px;
-    max-width: none; /* 모바일에서는 최대 너비 제한 해제 */
+    min-width: 100%;
+    max-width: 100%;
   }
 }
 

--- a/client/src/components/InfoSection/InfoSection.module.css
+++ b/client/src/components/InfoSection/InfoSection.module.css
@@ -1,4 +1,5 @@
 .infoSection {
+  width: fit-content;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;


### PR DESCRIPTION
## 요약
안녕하세요 첫 수정 한번 봐주시면 감사하겠습니다 🙇
웹에서 수온알리미 화면 볼 때 시간표 부분이 안 보였던걸 수정하고 싶었는데, 이렇게 수정해도 좋을지....
아래 참고 이미지로 전후 화면 남겨두겠습니다! 

<br />

## 참고 이미지

### 모바일 웹

제가 아이폰 16e를 사용하고 있는데, 가로 폭이 좁아서 좌측 테이블의 내용이 다 안 보이더라구요
반응형 처리를 해두면 어떨까? 해서 수정해봤습니다
또는 운영일정을 별도 탭으로 빼는건 어떨까? 하다가 오바쌈바같아서 그냥 뒀습니다... 

**전**
<img width="337" alt="스크린샷 2025-05-26 오전 9 50 31" src="https://github.com/user-attachments/assets/10017d8b-1e8b-4d1a-91da-7434076e0e8f" />
**후**
<img width="336" alt="스크린샷 2025-05-26 오전 9 50 10" src="https://github.com/user-attachments/assets/b2a20627-8244-443f-955b-d2fd81516e93" />

### PC 웹

웹에서 볼 때 우측 테이블 내용이 안 보이는 경우가 있어 좌/우 테이블 비율을 적절히.. 맞췄습니다
client/src/Layout.module.css 에서의 infoSection, schedule 클래스 건드렸는데 사용하지 않는 부분인거 같더라구요
혹시 사용하지 않는 코드들을 제거해도 될까요...? 

**전**
<img width="1075" alt="스크린샷 2025-05-26 오전 9 50 26" src="https://github.com/user-attachments/assets/c1a2d142-ab61-4a61-9036-4c54301cf0ee" />
**후**
<img width="1077" alt="스크린샷 2025-05-26 오전 9 50 03" src="https://github.com/user-attachments/assets/d68ebd35-5ea7-4af1-8ced-7a9add3306b5" />
